### PR TITLE
Split command argument for training path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ pipenv run python laughr.py --help
 
 Output:
 ```
-usage: laughr.py [-h] --model MODEL.h5
-                 [--train /path/to/L*.wav /path/to/D*.wav]
+usage: laughr.py [-h] --model MODEL.h5 [--train-laughs /path/to/laughs/files]
+                 [--train-non-laughs /path/to/non-laughs/files]
                  [--mute-laughs SOURCE.wav OUTPUT.wav]
 
 A tool to mute laugh tracks from an audio clip automatically. For example, to
@@ -69,12 +69,18 @@ Commands:
   --model MODEL.h5      When training, the Keras model is saved to this file
                         (overwrites!). When running only --mute-laughs, the
                         model is loaded from this file.
-  --train /path/to/L*.wav /path/to/D*.wav
-                        Train the model on the examples. Each glob should
-                        specify a set of audio files containing laugher, and a
-                        set containing non-laugher, respectively. You might
-                        use a tool like Audacity to label and "Export
-                        Multiple" to speed up creation of the training set.
+  --train-laughs /path/to/laughs/files
+                        Path to the directory with the set of '.wav' files
+                        containing laugher for training. You might use a tool
+                        like Audacity to label and "Export Multiple" to speed
+                        up creation of the training set with laugh samples and
+                        not-laugh samples at once.
+  --train-non-laughs /path/to/non-laughs/files
+                        Path to the directory with the set of ''.wav' files
+                        containing non-laugher for training. You might use a
+                        tool like Audacity to label and "Export Multiple" to
+                        speed up creation of the training set with laugh
+                        samples and not-laugh samples at once.
   --mute-laughs SOURCE.wav OUTPUT.wav
                         Identifies laugher in the source file, mutes it, and
                         saves the result in the output file.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ pipenv run python laughr.py --help
 
 Output:
 ```
-usage: laughr.py [-h] --model MODEL.h5 [--train-laughs /path/to/laughs/files]
-                 [--train-non-laughs /path/to/non-laughs/files]
+usage: laughr.py [-h] --model MODEL.h5 [--train-laughs /path/to/laughs]
+                 [--train-non-laughs /path/to/non-laughs]
                  [--mute-laughs SOURCE.wav OUTPUT.wav]
 
 A tool to mute laugh tracks from an audio clip automatically. For example, to
@@ -69,13 +69,13 @@ Commands:
   --model MODEL.h5      When training, the Keras model is saved to this file
                         (overwrites!). When running only --mute-laughs, the
                         model is loaded from this file.
-  --train-laughs /path/to/laughs/files
+  --train-laughs /path/to/laughs
                         Path to the directory with the set of '.wav' files
                         containing laugher for training. You might use a tool
                         like Audacity to label and "Export Multiple" to speed
                         up creation of the training set with laugh samples and
                         not-laugh samples at once.
-  --train-non-laughs /path/to/non-laughs/files
+  --train-non-laughs /path/to/non-laughs
                         Path to the directory with the set of ''.wav' files
                         containing non-laugher for training. You might use a
                         tool like Audacity to label and "Export Multiple" to

--- a/src/laughr.py
+++ b/src/laughr.py
@@ -251,10 +251,10 @@ if __name__ == '__main__':
     group.add_argument('--model', required=True, type=str, metavar='MODEL.h5',
                        help=model_help)
     group.add_argument('--train-laughs', type=str,
-                       metavar=('/path/to/laughs/files'),
+                       metavar=('/path/to/laughs'),
                        help=train_laughs_help)
     group.add_argument('--train-non-laughs', type=str,
-                      metavar=('/path/to/non-laughs/files'),
+                      metavar=('/path/to/non-laughs'),
                       help=train_non_laughs_help)
     group.add_argument('--mute-laughs', type=str, nargs=2,
                        metavar=('SOURCE.wav', 'OUTPUT.wav'),


### PR DESCRIPTION
Split original argument --train into --train-laughs and --train-non-laughs.
It prevents shell from expanding prefixes as a list of files.
Also update README accordingly.

Solves #2 